### PR TITLE
ENH: Add NDArrayOperatorsMixin

### DIFF
--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -1,3 +1,5 @@
+.. _neps.ufunc-overrides:
+
 =================================
 A Mechanism for Overriding Ufuncs
 =================================

--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -577,8 +577,8 @@ make more sense to ask classes like ``MyObject`` to implement a full
 ``__array_ufunc__`` [6]_. In the end, allowing classes to opt out was
 preferred, and the above reasoning led us to agree on a similar
 implementation for :class:`ndarray` itself. To help implement array-like
-classes, the mixin class :class:`~numpy.NDArrayOperatorsMixin` provides
-overrides for all binary operators with corresponding ufuncs.
+classes, the mixin class :class:`~numpy.lib.mixins.NDArrayOperatorsMixin`
+provides overrides for all binary operators with corresponding ufuncs.
 
 
 Future extensions to other functions

--- a/doc/neps/ufunc-overrides.rst
+++ b/doc/neps/ufunc-overrides.rst
@@ -5,7 +5,7 @@ A Mechanism for Overriding Ufuncs
 .. currentmodule:: numpy
 
 :Author: Blake Griffith
-:Contact: blake.g@utexas.edu 
+:Contact: blake.g@utexas.edu
 :Date: 2013-07-10
 
 :Author: Pauli Virtanen
@@ -94,7 +94,7 @@ Take this example of ufuncs interoperability with sparse matrices.::
     Out[4]: matrix([[16,  0,  8],
                     [ 8,  1,  5],
                     [ 4,  1,  4]], dtype=int64)
-                    
+
     In [5]: np.multiply(a, bsp) # Returns NotImplemented to user, bad!
     Out[5]: NotImplemted
 
@@ -147,11 +147,11 @@ signature is::
 
 Here:
 
-- *ufunc* is the ufunc object that was called. 
+- *ufunc* is the ufunc object that was called.
 - *method* is a string indicating how the Ufunc was called, either
   ``"__call__"`` to indicate it was called directly, or one of its
   :ref:`methods<ufuncs.methods>`: ``"reduce"``, ``"accumulate"``,
-  ``"reduceat"``, ``"outer"``, or ``"at"``. 
+  ``"reduceat"``, ``"outer"``, or ``"at"``.
 - *inputs* is a tuple of the input arguments to the ``ufunc``
 - *kwargs* contains any optional or keyword arguments passed to the
   function. This includes any ``out`` arguments, which are always
@@ -577,8 +577,8 @@ make more sense to ask classes like ``MyObject`` to implement a full
 ``__array_ufunc__`` [6]_. In the end, allowing classes to opt out was
 preferred, and the above reasoning led us to agree on a similar
 implementation for :class:`ndarray` itself. To help implement array-like
-classes, we will provide a mixin class that provides overrides for all
-binary operators.
+classes, the mixin class :class:`~numpy.NDArrayOperatorsMixin` provides
+overrides for all binary operators with corresponding ufuncs.
 
 
 Future extensions to other functions

--- a/doc/source/neps/ufunc-overrides.rst
+++ b/doc/source/neps/ufunc-overrides.rst
@@ -1,1 +1,3 @@
+.. _neps.ufunc-overides:
+
 .. include:: ../../neps/ufunc-overrides.rst

--- a/doc/source/neps/ufunc-overrides.rst
+++ b/doc/source/neps/ufunc-overrides.rst
@@ -1,3 +1,1 @@
-.. _neps.ufunc-overides:
-
 .. include:: ../../neps/ufunc-overrides.rst

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -128,7 +128,7 @@ NumPy provides several hooks that classes can customize:
       - If you are not a subclass of :class:`ndarray`, we recommend your
         class define special methods like ``__add__`` and ``__lt__`` that
         delegate to ufuncs just like ndarray does.  An easy way to do this
-        is to subclass from :class:`~numpy.NDArrayOperatorsMixin`.
+        is to subclass from :class:`~numpy.lib.mixins.NDArrayOperatorsMixin`.
       - If you subclass :class:`ndarray`, we strongly recommend that you
         avoid confusion by neither setting :func:`__array_ufunc__` to
         :obj:`None`, which makes no sense for an array subclass, nor by

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -127,8 +127,8 @@ NumPy provides several hooks that classes can customize:
 
       - If you are not a subclass of :class:`ndarray`, we recommend your
         class define special methods like ``__add__`` and ``__lt__`` that
-        delegate to ufuncs just like ndarray does.  We hope to provide a
-        helper mixin class for this.
+        delegate to ufuncs just like ndarray does.  An easy way to do this
+        is to subclass from :class:`~numpy.NDArrayOperatorsMixin`.
       - If you subclass :class:`ndarray`, we strongly recommend that you
         avoid confusion by neither setting :func:`__array_ufunc__` to
         :obj:`None`, which makes no sense for an array subclass, nor by

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -32,6 +32,13 @@ Memory ranges
    shares_memory
    may_share_memory
 
+Array mixins
+------------
+.. autosummary::
+   :toctree: generated/
+
+   NDArrayOperatorsMixin
+
 NumPy version comparison
 ------------------------
 .. autosummary::

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -37,7 +37,7 @@ Array mixins
 .. autosummary::
    :toctree: generated/
 
-   NDArrayOperatorsMixin
+   lib.mixins.NDArrayOperatorsMixin
 
 NumPy version comparison
 ------------------------

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -8,6 +8,7 @@ from numpy.version import version as __version__
 from .type_check import *
 from .index_tricks import *
 from .function_base import *
+from .mixins import *
 from .nanfunctions import *
 from .shape_base import *
 from .stride_tricks import *
@@ -29,6 +30,7 @@ __all__ = ['emath', 'math']
 __all__ += type_check.__all__
 __all__ += index_tricks.__all__
 __all__ += function_base.__all__
+__all__ += mixins.__all__
 __all__ += shape_base.__all__
 __all__ += stride_tricks.__all__
 __all__ += twodim_base.__all__

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -61,17 +61,18 @@ class NDArrayOperatorsMixin(object):
 
     This class implements the special methods for almost all of Python's
     builtin operators defined in the `operator` module, including comparisons
-    (==, >, etc.) and arithmetic (+, *, -, etc.), by deferring to a
-    __array_ufunc__ method.
+    (``==``, ``>``, etc.) and arithmetic (``+``, ``*``, ``-``, etc.), by
+    deferring to the ``__array_ufunc__`` method, which subclasses must
+    implement.
 
     This class does not yet implement the special operators corresponding
-    to `divmod`, unary `+` or `matmul` (`@`), because these operation do not
-    yet have corresponding NumPy ufuncs.
+    to ``divmod``, unary ``+`` or ``matmul`` (``@``), because these operation
+    do not yet have corresponding NumPy ufuncs.
 
     It is useful for writing classes that do not inherit from `numpy.ndarray`,
     but that should support arithmetic and numpy universal functions like
-    arrays as described in `A Mechanism for Overriding Ufuncs
-    <neps.ufunc-overides>`_.
+    arrays as described in :ref:`A Mechanism for Overriding Ufuncs
+    <neps.ufunc-overrides>`.
 
     As an trivial example, consider this implementation of an ``ArrayLike``
     class that simply wraps a NumPy array and ensures that the result of any
@@ -81,7 +82,8 @@ class NDArrayOperatorsMixin(object):
             def __init__(self, value):
                 self.value = np.asarray(value)
 
-            # We might also consider adding the built-in list type to this list
+            # One might also consider adding the built-in list type to this
+            # list, to support operations like np.add(array_like, list)
             _HANDLED_TYPES = (np.ndarray, numbers.Number)
 
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -4,6 +4,7 @@ Mixin classes for writing custom array types that don't inherit from ndarray.
 from __future__ import division, absolute_import, print_function
 
 import operator
+import sys
 
 from numpy.core import umath as um
 
@@ -83,7 +84,9 @@ class NDArrayOperatorsMixin(object):
     __add__, __radd__, __iadd__ = _numeric_methods(um.add)
     __sub__, __rsub__, __isub__ = _numeric_methods(um.subtract)
     __mul__, __rmul__, __imul__ = _numeric_methods(um.multiply)
-    __div__, __rdiv__, __idiv__ = _numeric_methods(um.divide)  # Python 2 only
+    if sys.version_info.major < 3:
+        # Python 3 uses only __truediv__ and __floordiv__
+        __div__, __rdiv__, __idiv__ = _numeric_methods(um.divide)
     __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(um.true_divide)
     __floordiv__, __rfloordiv__, __ifloordiv__ = _numeric_methods(
         um.floor_divide)

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -58,10 +58,9 @@ def _unary_method(ufunc):
 class NDArrayOperatorsMixin(object):
     """Implements (almost) all special methods using __array_ufunc__.
 
-    Caveats: this class does not implement the special operators corresponding
-    to `divmod`, unary `+` or `matmul` (`@`), because these operation does not
-    have corresponding NumPy ufuncs. If you need these operations, you will
-    need to implement them yourself.
+    This class does not yet implement the special operators corresponding
+    to `divmod`, unary `+` or `matmul` (`@`), because these operation do not yet
+    have corresponding NumPy ufuncs.
     """
 
     # comparisons don't have reflected and in-place versions

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -6,7 +6,8 @@ import sys
 
 from numpy.core import umath as um
 
-__all__ = ['NDArrayOperatorsMixin']
+# None of this module should be exposed in top-level NumPy module.
+__all__ = []
 
 
 def _binary_method(ufunc):
@@ -56,11 +57,80 @@ def _unary_method(ufunc):
 
 
 class NDArrayOperatorsMixin(object):
-    """Implements (almost) all special methods using __array_ufunc__.
+    """Mixin defining all operator special methods using __array_ufunc__.
+
+    This class implements the special methods for almost all of Python's
+    builtin operators defined in the `operator` module, including comparisons
+    (==, >, etc.) and arithmetic (+, *, -, etc.), by deferring to a
+    __array_ufunc__ method.
 
     This class does not yet implement the special operators corresponding
-    to `divmod`, unary `+` or `matmul` (`@`), because these operation do not yet
-    have corresponding NumPy ufuncs.
+    to `divmod`, unary `+` or `matmul` (`@`), because these operation do not
+    yet have corresponding NumPy ufuncs.
+
+    It is useful for writing classes that do not inherit from `numpy.ndarray`,
+    but that should support arithmetic and numpy universal functions like
+    arrays as described in `A Mechanism for Overriding Ufuncs
+    <neps.ufunc-overides>`_.
+
+    As an trivial example, consider this implementation of an ``ArrayLike``
+    class that simply wraps a NumPy array and ensures that the result of any
+    arithmetic operation is also an ``ArrayLike`` object::
+
+        class ArrayLike(np.lib.mixins.NDArrayOperatorsMixin):
+            def __init__(self, value):
+                self.value = np.asarray(value)
+
+            # We might also consider adding the built-in list type to this list
+            _HANDLED_TYPES = (np.ndarray, numbers.Number)
+
+            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+                out = kwargs.get('out', ())
+                for x in inputs + out:
+                    # Only support operations with instances of _HANDLED_TYPES
+                    # and superclass instances of this type
+                    if not (isinstance(x, self._HANDLED_TYPES) or
+                            isinstance(self, type(x))):
+                        return NotImplemented
+
+                # Defer to the implementation of the ufunc on unwrapped values
+                inputs = tuple(x.value if isinstance(self, type(x)) else x
+                               for x in inputs)
+                if out:
+                    kwargs['out'] = tuple(
+                        x.value if isinstance(self, type(x)) else x
+                        for x in out)
+                result = getattr(ufunc, method)(*inputs, **kwargs)
+
+                if type(result) is tuple:
+                    # multiple return values
+                    return tuple(type(self)(x) for x in result)
+                elif method == 'at':
+                    # no return value
+                    return None
+                else:
+                    # one return value
+                    return type(self)(result)
+
+            def __repr__(self):
+                return '%s(%r)' % (type(self).__name__, self.value)
+
+    In interactions between ``ArrayLike`` objects and numbers or numpy arrays,
+    the result is always another ``ArrayLike``:
+
+        >>> x = ArrayLike([1, 2, 3])
+        >>> x - 1
+        ArrayLike(array([0, 1, 2]))
+        >>> 1 - x
+        ArrayLike(array([ 0, -1, -2]))
+        >>> np.arange(3) - x
+        ArrayLike(array([-1, -1, -1]))
+        >>> x - np.arange(3)
+        ArrayLike(array([1, 1, 1]))
+
+    Note that unlike ``numpy.ndarray``, ``ArrayLike`` does not allow operations
+    with arbitrary, unrecognized types. This ensures that interactions with
+    ArrayLike preserve a well-defined casting hierarchy.
     """
 
     # comparisons don't have reflected and in-place versions

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -1,5 +1,4 @@
-"""Mixin classes for custom array types that don't inherit from ndarray.
-"""
+"""Mixin classes for custom array types that don't inherit from ndarray."""
 from __future__ import division, absolute_import, print_function
 
 import sys

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -93,9 +93,9 @@ class NDArrayOperatorsMixin(object):
     __pow__, __rpow__, __ipow__ = _numeric_methods(um.power)
     __lshift__, __rlshift__, __ilshift__ = _numeric_methods(um.left_shift)
     __rshift__, __rrshift__, __irshift__ = _numeric_methods(um.right_shift)
-    __and__, __rand__, __iand__ = _numeric_methods(um.logical_and)
-    __xor__, __rxor__, __ixor__ = _numeric_methods(um.logical_xor)
-    __or__, __ror__, __ior__ = _numeric_methods(um.logical_or)
+    __and__, __rand__, __iand__ = _numeric_methods(um.bitwise_and)
+    __xor__, __rxor__, __ixor__ = _numeric_methods(um.bitwise_xor)
+    __or__, __ror__, __ior__ = _numeric_methods(um.bitwise_or)
 
     # unary methods
     __neg__ = _unary_method(um.negative)

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -1,9 +1,7 @@
-"""
-Mixin classes for writing custom array types that don't inherit from ndarray.
+"""Mixin classes for custom array types that don't inherit from ndarray.
 """
 from __future__ import division, absolute_import, print_function
 
-import operator
 import sys
 
 from numpy.core import umath as um
@@ -58,18 +56,12 @@ def _unary_method(ufunc):
 
 
 class NDArrayOperatorsMixin(object):
-    """Implements all special methods using __array_ufunc__.
+    """Implements (almost) all special methods using __array_ufunc__.
 
-    Caveats:
-    (1) The rarely used `divmod` (``__divmod__``) and unary `+` (``__pos__``)
-        operators do not have corresponding ufuncs. Hence this mixin passes the
-        builtin functions ``divmod`` and ``operator.pos`` to
-        ``__array_ufunc__`` instead of true ufuncs. If you inherit from this
-        mixin, your implementation needs to be able to handle this or you
-        should override these methods.
-    (2) This mixin doesn't define ``__matmul__``, ``__rmatmul__`` and
-        ``__imatmul__``, because ``np.matmul`` is not a ufunc, and hence does
-        not call ``__array_ufunc__``.
+    Caveats: this class does not implement the special operators corresponding
+    to `divmod`, unary `+` or `matmul` (`@`), because these operation does not
+    have corresponding NumPy ufuncs. If you need these operations, you will
+    need to implement them yourself.
     """
 
     # comparisons don't have reflected and in-place versions
@@ -91,7 +83,6 @@ class NDArrayOperatorsMixin(object):
     __floordiv__, __rfloordiv__, __ifloordiv__ = _numeric_methods(
         um.floor_divide)
     __mod__, __rmod__, __imod__ = _numeric_methods(um.mod)
-    __divmod__, __rdivmod__, __idivmod__ = _numeric_methods(divmod)
     # TODO: handle the optional third argument for __pow__?
     __pow__, __rpow__, __ipow__ = _numeric_methods(um.power)
     __lshift__, __rlshift__, __ilshift__ = _numeric_methods(um.left_shift)
@@ -102,6 +93,5 @@ class NDArrayOperatorsMixin(object):
 
     # unary methods
     __neg__ = _unary_method(um.negative)
-    __pos__ = _unary_method(operator.pos)
     __abs__ = _unary_method(um.absolute)
     __invert__ = _unary_method(um.invert)

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -62,10 +62,10 @@ class NDArrayOperatorsMixin(object):
     Caveats:
     (1) The rarely used `divmod` (``__divmod__``) and unary `+` (``__pos__``)
         operators do not have corresponding ufuncs. Hence this mixin passes the
-        builtin functions ``divmod`` and ``operator.pos`` to ``__array_ufunc__``
-        instead of true ufuncs. If you inherit from this mixin, your
-        implementation needs to be able to handle this or you should override
-        these methods.
+        builtin functions ``divmod`` and ``operator.pos`` to
+        ``__array_ufunc__`` instead of true ufuncs. If you inherit from this
+        mixin, your implementation needs to be able to handle this or you
+        should override these methods.
     (2) This mixin doesn't define ``__matmul__``, ``__rmatmul__`` and
         ``__imatmul__``, because ``np.matmul`` is not a ufunc, and hence does
         not call ``__array_ufunc__``.

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -1,0 +1,101 @@
+"""
+Mixin classes for writing custom array types that don't inherit from ndarray.
+"""
+from __future__ import division, absolute_import, print_function
+
+import operator
+
+import numpy as np
+
+__all__ = ['NDArrayOperatorsMixin']
+
+
+def _binary_method(ufunc):
+    def func(self, other):
+        try:
+            if other.__array_ufunc__ is None:
+                return NotImplemented
+        except AttributeError:
+            pass
+        return self.__array_ufunc__(ufunc, '__call__', self, other)
+    return func
+
+
+def _reflected_binary_method(ufunc):
+    def func(self, other):
+        try:
+            if other.__array_ufunc__ is None:
+                return NotImplemented
+        except AttributeError:
+            pass
+        return self.__array_ufunc__(ufunc, '__call__', other, self)
+    return func
+
+
+def _inplace_binary_method(ufunc):
+    def func(self, other):
+        result = self.__array_ufunc__(
+            ufunc, '__call__', self, other, out=(self,))
+        if result is NotImplemented:
+            raise TypeError('unsupported operand types for in-place '
+                            'arithmetic: %s and %s'
+                            % (type(self).__name__, type(other).__name__))
+        return result
+    return func
+
+
+def _numeric_methods(ufunc):
+    return (_binary_method(ufunc),
+            _reflected_binary_method(ufunc),
+            _inplace_binary_method(ufunc))
+
+
+def _unary_method(ufunc):
+    def func(self):
+        return self.__array_ufunc__(ufunc, '__call__', self)
+    return func
+
+
+class NDArrayOperatorsMixin(object):
+    """Implements all special methods using __array_ufunc__.
+
+    Caveats: the rarely used `divmod` (``__divmod__``) and unary `+`
+    (``__pos__``) operators do not have corresponding ufuncs. Hence this mixin
+    passes the builtin functions ``divmod`` and ``operator.pos`` to
+    ``__array_ufunc__`` instead of true ufuncs. If you inherit from this mixin,
+    your implementation needs to be able to handle this or you should override
+    these methods.
+    """
+
+    # comparisons don't have reflected and in-place versions
+    __lt__ = _binary_method(np.less)
+    __le__ = _binary_method(np.less_equal)
+    __eq__ = _binary_method(np.equal)
+    __ne__ = _binary_method(np.not_equal)
+    __gt__ = _binary_method(np.greater)
+    __ge__ = _binary_method(np.greater_equal)
+
+    # numeric methods
+    __add__, __radd__, __iadd__ = _numeric_methods(np.add)
+    __sub__, __rsub__, __isub__ = _numeric_methods(np.subtract)
+    __mul__, __rmul__, __imul__ = _numeric_methods(np.multiply)
+    __matmul__, __rmatmul__, __imatmul__ = _numeric_methods(np.matmul)
+    __div__, __rdiv__, __idiv__ = _numeric_methods(np.divide)  # Python 2 only
+    __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(np.true_divide)
+    __floordiv__, __rfloordiv__, __ifloordiv__ = _numeric_methods(
+        np.floor_divide)
+    __mod__, __rmod__, __imod__ = _numeric_methods(np.mod)
+    __divmod__, __rdivmod__, __idivmod__ = _numeric_methods(divmod)
+    # TODO: handle the optional third argument for __pow__?
+    __pow__, __rpow__, __ipow__ = _numeric_methods(np.power)
+    __lshift__, __rlshift__, __ilshift__ = _numeric_methods(np.left_shift)
+    __rshift__, __rrshift__, __irshift__ = _numeric_methods(np.right_shift)
+    __and__, __rand__, __iand__ = _numeric_methods(np.logical_and)
+    __xor__, __rxor__, __ixor__ = _numeric_methods(np.logical_xor)
+    __or__, __ror__, __ior__ = _numeric_methods(np.logical_or)
+
+    # unary methods
+    __neg__ = _unary_method(np.negative)
+    __pos__ = _unary_method(operator.pos)
+    __abs__ = _unary_method(np.absolute)
+    __invert__ = _unary_method(np.invert)

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -5,7 +5,7 @@ from __future__ import division, absolute_import, print_function
 
 import operator
 
-import numpy as np
+from numpy.core import umath as um
 
 __all__ = ['NDArrayOperatorsMixin']
 
@@ -59,43 +59,46 @@ def _unary_method(ufunc):
 class NDArrayOperatorsMixin(object):
     """Implements all special methods using __array_ufunc__.
 
-    Caveats: the rarely used `divmod` (``__divmod__``) and unary `+`
-    (``__pos__``) operators do not have corresponding ufuncs. Hence this mixin
-    passes the builtin functions ``divmod`` and ``operator.pos`` to
-    ``__array_ufunc__`` instead of true ufuncs. If you inherit from this mixin,
-    your implementation needs to be able to handle this or you should override
-    these methods.
+    Caveats:
+    (1) The rarely used `divmod` (``__divmod__``) and unary `+` (``__pos__``)
+        operators do not have corresponding ufuncs. Hence this mixin passes the
+        builtin functions ``divmod`` and ``operator.pos`` to ``__array_ufunc__``
+        instead of true ufuncs. If you inherit from this mixin, your
+        implementation needs to be able to handle this or you should override
+        these methods.
+    (2) This mixin doesn't define ``__matmul__``, ``__rmatmul__`` and
+        ``__imatmul__``, because ``np.matmul`` is not a ufunc, and hence does
+        not call ``__array_ufunc__``.
     """
 
     # comparisons don't have reflected and in-place versions
-    __lt__ = _binary_method(np.less)
-    __le__ = _binary_method(np.less_equal)
-    __eq__ = _binary_method(np.equal)
-    __ne__ = _binary_method(np.not_equal)
-    __gt__ = _binary_method(np.greater)
-    __ge__ = _binary_method(np.greater_equal)
+    __lt__ = _binary_method(um.less)
+    __le__ = _binary_method(um.less_equal)
+    __eq__ = _binary_method(um.equal)
+    __ne__ = _binary_method(um.not_equal)
+    __gt__ = _binary_method(um.greater)
+    __ge__ = _binary_method(um.greater_equal)
 
     # numeric methods
-    __add__, __radd__, __iadd__ = _numeric_methods(np.add)
-    __sub__, __rsub__, __isub__ = _numeric_methods(np.subtract)
-    __mul__, __rmul__, __imul__ = _numeric_methods(np.multiply)
-    __matmul__, __rmatmul__, __imatmul__ = _numeric_methods(np.matmul)
-    __div__, __rdiv__, __idiv__ = _numeric_methods(np.divide)  # Python 2 only
-    __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(np.true_divide)
+    __add__, __radd__, __iadd__ = _numeric_methods(um.add)
+    __sub__, __rsub__, __isub__ = _numeric_methods(um.subtract)
+    __mul__, __rmul__, __imul__ = _numeric_methods(um.multiply)
+    __div__, __rdiv__, __idiv__ = _numeric_methods(um.divide)  # Python 2 only
+    __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(um.true_divide)
     __floordiv__, __rfloordiv__, __ifloordiv__ = _numeric_methods(
-        np.floor_divide)
-    __mod__, __rmod__, __imod__ = _numeric_methods(np.mod)
+        um.floor_divide)
+    __mod__, __rmod__, __imod__ = _numeric_methods(um.mod)
     __divmod__, __rdivmod__, __idivmod__ = _numeric_methods(divmod)
     # TODO: handle the optional third argument for __pow__?
-    __pow__, __rpow__, __ipow__ = _numeric_methods(np.power)
-    __lshift__, __rlshift__, __ilshift__ = _numeric_methods(np.left_shift)
-    __rshift__, __rrshift__, __irshift__ = _numeric_methods(np.right_shift)
-    __and__, __rand__, __iand__ = _numeric_methods(np.logical_and)
-    __xor__, __rxor__, __ixor__ = _numeric_methods(np.logical_xor)
-    __or__, __ror__, __ior__ = _numeric_methods(np.logical_or)
+    __pow__, __rpow__, __ipow__ = _numeric_methods(um.power)
+    __lshift__, __rlshift__, __ilshift__ = _numeric_methods(um.left_shift)
+    __rshift__, __rrshift__, __irshift__ = _numeric_methods(um.right_shift)
+    __and__, __rand__, __iand__ = _numeric_methods(um.logical_and)
+    __xor__, __rxor__, __ixor__ = _numeric_methods(um.logical_xor)
+    __or__, __ror__, __ior__ = _numeric_methods(um.logical_or)
 
     # unary methods
-    __neg__ = _unary_method(np.negative)
+    __neg__ = _unary_method(um.negative)
     __pos__ = _unary_method(operator.pos)
-    __abs__ = _unary_method(np.absolute)
-    __invert__ = _unary_method(np.invert)
+    __abs__ = _unary_method(um.absolute)
+    __invert__ = _unary_method(um.invert)

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -1,0 +1,102 @@
+from __future__ import division, absolute_import, print_function
+
+import numbers
+
+import numpy as np
+from numpy.testing import TestCase, run_module_suite, assert_, assert_equal
+
+
+class ArrayLike(np.NDArrayOperatorsMixin):
+    """An array-like class that wraps NumPy arrays.
+
+    Example usage:
+        >>> x = ArrayLike([1, 2, 3])
+        >>> x - 1
+        ArrayLike(array([0, 1, 2]))
+        >>> 1 - x
+        ArrayLike(array([ 0, -1, -2]))
+        >>> np.arange(3) - x
+        ArrayLike(array([-1, -1, -1]))
+        >>> x - np.arange(3)
+        ArrayLike(array([1, 1, 1]))
+    """
+
+    def __init__(self, value):
+        self.value = np.asarray(value)
+
+    # __array_priority__ = 1000  # for legacy reasons
+
+    _handled_types = (np.ndarray, numbers.Number)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        # ArrayLike implements arithmetic and ufuncs by deferring to the
+        # wrapped array
+        out = kwargs.get('out', ())
+        for x in inputs + out:
+            # handle _handled_types and superclass instances
+            if not (isinstance(x, self._handled_types) or
+                    isinstance(self, type(x))):
+                return NotImplemented
+
+        inputs = tuple(x.value if isinstance(self, type(x)) else x
+                       for x in inputs)
+        if out:
+            kwargs['out'] = tuple(x.value if isinstance(self, type(x)) else x
+                                  for x in out)
+        result = getattr(ufunc, method)(*inputs, **kwargs)
+        if isinstance(result, tuple):
+            return tuple(type(self)(x) for x in result)
+        else:
+            return type(self)(result)
+
+    def __repr__(self):
+        return '%s(%r)' % (type(self).__name__, self.value)
+
+
+class TestNDArrayOperatorsMixin(TestCase):
+
+    def test_array_like(self):
+
+        x = ArrayLike(1)
+        assert_(isinstance(x + 1, ArrayLike))
+        assert_equal((x + 1).value, 2)
+
+    def test_opt_out(self):
+
+        class OptOut(object):
+            """Object that opts out of __array_ufunc__."""
+            __array_ufunc__ = None
+
+            def __add__(self, other):
+                return self
+
+            def __radd__(self, other):
+                return self
+
+        x = ArrayLike(1)
+        o = OptOut()
+        assert_(isinstance(x + o), OptOut)
+        assert_(isinstance(o + x), OptOut)
+
+    def test_subclass(self):
+
+        class SubArrayLike(ArrayLike):
+            """Should take precedence over ArrayLike."""
+
+        # TODO
+
+    def test_ndarray(self):
+        pass
+
+    def test_ndarray_subclass(self):
+        pass
+
+    def test_out(self):
+        pass
+
+    def test_all_operators(self):
+        pass
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import numbers
 import operator
 import sys
+import warnings
 
 import numpy as np
 from numpy.testing import (
@@ -190,11 +191,16 @@ class TestNDArrayOperatorsMixin(TestCase):
         if PY2:
             operators.append(operator.div)
 
-        for op in operators:
-            expected = ArrayLike(op(array, 1))
-            actual = op(array_like, 1)
-            err_msg = 'failed for operator {}'.format(op)
-            _assert_equal_type_and_value(expected, actual, err_msg=err_msg)
+        with warnings.catch_warnings():
+            # ignore warnings from operator.div when run with python -3
+            warnings.filterwarnings('ignore', 'classic int division',
+                                    DeprecationWarning)
+
+            for op in operators:
+                expected = ArrayLike(op(array, 1))
+                actual = op(array_like, 1)
+                err_msg = 'failed for operator {}'.format(op)
+                _assert_equal_type_and_value(expected, actual, err_msg=err_msg)
 
 
 if __name__ == "__main__":

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -75,8 +75,8 @@ class TestNDArrayOperatorsMixin(TestCase):
 
         x = ArrayLike(1)
         o = OptOut()
-        assert_(isinstance(x + o), OptOut)
-        assert_(isinstance(o + x), OptOut)
+        assert_(isinstance(x + o, OptOut))
+        assert_(isinstance(o + x, OptOut))
 
     def test_subclass(self):
 

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -10,7 +10,7 @@ from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises)
 
 
-PY2 = sys.version_info[0] < 3
+PY2 = sys.version_info.major < 3
 
 
 class ArrayLike(np.NDArrayOperatorsMixin):
@@ -57,7 +57,7 @@ class ArrayLike(np.NDArrayOperatorsMixin):
             # one return value
             return type(self)(result)
         else:
-            # no return return value, e.g., ufunc.at
+            # no return value, e.g., ufunc.at
             return None
 
     def __repr__(self):
@@ -91,7 +91,7 @@ class TestNDArrayOperatorsMixin(TestCase):
         check(np.array(0) + ArrayLike(np.array(0)))
 
     def test_divmod(self):
-        # divmod is subtle: it's returns a tuple
+        # divmod is subtle: its returns a tuple
 
         def check(result):
             assert_(type(result) is tuple)

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 import numbers
 import operator
 import sys
-import warnings
 
 import numpy as np
 from numpy.testing import (
@@ -17,6 +16,7 @@ class ArrayLike(np.NDArrayOperatorsMixin):
     """An array-like class that wraps NumPy arrays.
 
     Example usage:
+
         >>> x = ArrayLike([1, 2, 3])
         >>> x - 1
         ArrayLike(array([0, 1, 2]))
@@ -26,11 +26,17 @@ class ArrayLike(np.NDArrayOperatorsMixin):
         ArrayLike(array([-1, -1, -1]))
         >>> x - np.arange(3)
         ArrayLike(array([1, 1, 1]))
+
+    Note that unlike numpy.ndarray, this type does not allow operations with
+    arbitrary, unrecognized types. This ensures that ArrayLike maintains a
+    well-defined casting hierarchy, as described in the NEP "A Mechanism for
+    Overriding Ufuncs".
     """
 
     def __init__(self, value):
         self.value = np.asarray(value)
 
+    # We might also consider adding the built-in list type to this list
     _handled_types = (np.ndarray, numbers.Number)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
@@ -41,7 +47,6 @@ class ArrayLike(np.NDArrayOperatorsMixin):
             # handle _handled_types and superclass instances
             if not (isinstance(x, self._handled_types) or
                     isinstance(self, type(x))):
-                print('not implemented', type(x))
                 return NotImplemented
 
         inputs = tuple(x.value if isinstance(self, type(x)) else x

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -12,14 +12,15 @@ from numpy.testing import (
 PY2 = sys.version_info.major < 3
 
 
-# NOTE: This class is an exact copy of the example from docstring for
-# NDArrayOperatorsMixin
+# NOTE: This class should be kept as an exact copy of the example from the
+# docstring for NDArrayOperatorsMixin.
 
 class ArrayLike(np.lib.mixins.NDArrayOperatorsMixin):
     def __init__(self, value):
         self.value = np.asarray(value)
 
-    # We might also consider adding the built-in list type to this list
+    # One might also consider adding the built-in list type to this
+    # list, to support operations like np.add(array_like, list)
     _HANDLED_TYPES = (np.ndarray, numbers.Number)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):


### PR DESCRIPTION
This mixin class provides an easy way to implement arithmetic operators that defer to `__array_ufunc__` like `numpy.ndarray` in non-ndarray subclasses.