### PR TITLE
BUG: Support nout == 0 and at method

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1923,13 +1923,16 @@ class TestSpecialMethods(TestCase):
                 if results is NotImplemented:
                     return NotImplemented
 
+                if method == 'at':
+                    return
+
                 if ufunc.nout == 1:
                     results = (results,)
 
                 results = tuple((np.asarray(result).view(A)
                                  if output is None else output)
                                 for result, output in zip(results, outputs))
-                if isinstance(results[0], A):
+                if results and isinstance(results[0], A):
                     results[0].info = info
 
                 return results[0] if len(results) == 1 else results
@@ -1942,8 +1945,8 @@ class TestSpecialMethods(TestCase):
                     return NotImplemented
 
         d = np.arange(5.)
-        a = np.arange(5.).view(A)
         # 1 input, 1 output
+        a = np.arange(5.).view(A)
         b = np.sin(a)
         check = np.sin(d)
         assert_(np.all(check == b))
@@ -1956,6 +1959,7 @@ class TestSpecialMethods(TestCase):
         b = np.sin(a, out=a)
         assert_(np.all(check == b))
         assert_equal(b.info, {'inputs': [0], 'outputs': [0]})
+
         # 1 input, 2 outputs
         a = np.arange(5.).view(A)
         b1, b2 = np.modf(a)
@@ -1969,6 +1973,7 @@ class TestSpecialMethods(TestCase):
         assert_(c1 is a)
         assert_(c2 is b)
         assert_equal(c1.info, {'inputs': [0], 'outputs': [0, 1]})
+
         # 2 input, 1 output
         a = np.arange(5.).view(A)
         b = np.arange(5.).view(A)

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -488,13 +488,16 @@ following.
             if results is NotImplemented:
                 return NotImplemented
 
+            if method == 'at':
+                return
+
             if ufunc.nout == 1:
                 results = (results,)
 
             results = tuple((np.asarray(result).view(A)
                              if output is None else output)
                             for result, output in zip(results, outputs))
-            if isinstance(results[0], A):
+            if results and isinstance(results[0], A):
                 results[0].info = info
 
             return results[0] if len(results) == 1 else results


### PR DESCRIPTION
Not tested yet, because there's actually a bug here where `np.ufunc.at` is able to return non-none values, so tests would fail