### PR TITLE
ENH: Better error message for __array_ufunc__ not implemented

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -645,3 +645,15 @@ class AxisError(ValueError, IndexError):
                 msg = "{}: {}".format(msg_prefix, msg)
 
         super(AxisError, self).__init__(msg)
+
+
+def array_ufunc_errmsg_formatter(ufunc, method, *inputs, **kwargs):
+    """ Format the error message for when __array_ufunc__ gives up. """
+    args_string = ', '.join(['{!r}'.format(arg) for arg in inputs] +
+                            ['{}={!r}'.format(k, v)
+                             for k, v in kwargs.items()])
+    args = inputs + kwargs.get('out', ())
+    types_string = ', '.join(repr(type(arg).__name__) for arg in args)
+    return ('operand type(s) do not implement __array_ufunc__'
+            '({!r}, {!r}, {}): {}'
+            .format(ufunc, method, args_string, types_string))

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -258,7 +258,7 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
         out = PyDict_GetItemString(normal_kwds, "out");
         if (out != NULL) {
             int nout = ufunc->nout;
-            
+
             if (PyTuple_Check(out)) {
                 int all_none = 1;
 
@@ -429,8 +429,19 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
         /* Check if there is a method left to call */
         if (!override_obj) {
             /* No acceptable override found. */
-            PyErr_SetString(PyExc_TypeError,
-                            "__array_ufunc__ not implemented for this type.");
+            static PyObject *errmsg_formatter = NULL;
+            PyObject *errmsg;
+
+            npy_cache_import("numpy.core._internal",
+                             "array_ufunc_errmsg_formatter",
+                             &errmsg_formatter);
+            errmsg = PyObject_Call(errmsg_formatter, override_args,
+                                   normal_kwds);
+            if (errmsg == NULL) {
+                goto fail;
+            }
+            PyErr_SetObject(PyExc_TypeError, errmsg);
+            Py_DECREF(errmsg);
             goto fail;
         }
 

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -435,13 +435,14 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
             npy_cache_import("numpy.core._internal",
                              "array_ufunc_errmsg_formatter",
                              &errmsg_formatter);
-            errmsg = PyObject_Call(errmsg_formatter, override_args,
-                                   normal_kwds);
-            if (errmsg == NULL) {
-                goto fail;
+            if (errmsg_formatter != NULL) {
+                errmsg = PyObject_Call(errmsg_formatter, override_args,
+                                       normal_kwds);
+                if (errmsg != NULL) {
+                    PyErr_SetObject(PyExc_TypeError, errmsg);
+                    Py_DECREF(errmsg);
+                }
             }
-            PyErr_SetObject(PyExc_TypeError, errmsg);
-            Py_DECREF(errmsg);
             goto fail;
         }
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import platform
 import warnings
+import fnmatch
 import itertools
 
 from numpy.testing.utils import _gen_alignment_data
@@ -11,8 +12,9 @@ from numpy.core import umath_tests as ncu_tests
 import numpy as np
 from numpy.testing import (
     TestCase, run_module_suite, assert_, assert_equal, assert_raises,
-    assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    dec, assert_allclose, assert_no_warnings, suppress_warnings
+    assert_raises_regex, assert_array_equal, assert_almost_equal,
+    assert_array_almost_equal, dec, assert_allclose, assert_no_warnings,
+    suppress_warnings
 )
 
 
@@ -1882,6 +1884,22 @@ class TestSpecialMethods(TestCase):
         assert_raises(ValueError, np.negative, 1, out=a)
         assert_raises(ValueError, np.negative, a)
         assert_raises(ValueError, np.divide, 1., a)
+
+    def test_ufunc_override_not_implemented(self):
+
+        class A(object):
+            __array_ufunc__ = None
+
+        msg = ("operand type(s) do not implement __array_ufunc__("
+               "<ufunc 'negative'>, '__call__', <*>): 'A'")
+        with assert_raises_regex(TypeError, fnmatch.translate(msg)):
+            np.negative(A())
+
+        msg = ("operand type(s) do not implement __array_ufunc__("
+               "<ufunc 'add'>, '__call__', <*>, <object *>, out=(1,)): "
+               "'A', 'object', 'int'")
+        with assert_raises_regex(TypeError, fnmatch.translate(msg)):
+            np.add(A(), object(), out=1)
 
     def test_gufunc_override(self):
         # gufunc are just ufunc instances, but follow a different path,


### PR DESCRIPTION
New behavior:

    >>> import numpy as np

    >>> class Dummy:
    ...     def __array_ufunc__(self, *args, **kwargs):
    ...         return NotImplemented

    >>> np.negative(Dummy())
    TypeError: operand type(s) do not implement __array_ufunc__(
    <ufunc 'negative'>, '__call__', <__main__.Dummy object at 0x1106df8d0>):
    'Dummy'

EDIT: updated error message to final implementation